### PR TITLE
[NEP-14141] allow widget user to set total count

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dashboard",
-  "version": "1.3.0rc1",
+  "version": "1.4.0rc1",
   "homepage": "https://github.com/jobready/react-dashboard",
   "authors": [
     "Andrew McNamara <andrewm@jobready.com.au>"

--- a/dist/react-dashboard.js
+++ b/dist/react-dashboard.js
@@ -36363,6 +36363,8 @@ var ListWidget = React.createClass({
             );
         }
 
+        var total = this.state.data.total || this.state.data.items.length;
+
         return React.createElement(
             "div",
             { className: "panel panel-default" },
@@ -36375,7 +36377,7 @@ var ListWidget = React.createClass({
                 React.createElement(
                     "span",
                     { className: "badge pull-right bg-primary" },
-                    this.state.data.items.length
+                    total
                 )
             ),
             React.createElement(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dashboard",
-  "version": "1.3.0rc1",
+  "version": "1.4.0rc1",
   "description": "",
   "main": "dist/react-dashboard.js",
   "dependencies": {

--- a/src/components/ListWidget.js
+++ b/src/components/ListWidget.js
@@ -16,7 +16,7 @@ var ListWidget = React.createClass({
     },
 
     getInitialState: function () {
-        return {data: {items: []},  enabled: this.props.enabled};
+        return {data: {items: [], total: null},  enabled: this.props.enabled};
     },
 
     loadItems: function () {
@@ -61,13 +61,16 @@ var ListWidget = React.createClass({
             title = <a href={this.props.showAllUrl}>{title}</a>
         }
 
+        // if total is not null, then not all items are returned.
+        var total = this.state.data.total || this.state.data.items.length;
+
         return (
             <div className="panel panel-default">
                 <div className="panel-heading" onClick={this.handleClick} >
                     <i className={classes}/>
                     {title}
                     {saveButton}
-                    <span className="badge pull-right bg-primary">{this.state.data.items.length}</span>
+                    <span className="badge pull-right bg-primary">{total}</span>
                 </div>
                 <div className="panel-body" style={this.scrollableStyles()}>
                     <div className="list-group">


### PR DESCRIPTION
Ticket: https://jobready.atlassian.net/browse/NEP-14141

This PR allows widget users to set an optional `total` count, when it's provided, the widget will display `total` instead of `items.size`
This is to help the case that not all items will be provided at once. (e.g. { `total`: 5000, items: [...50 entries...] }

**Please also note:**
- There is evidence that the last 2 PRs https://github.com/rdytech/react-dashboard/pull/9 and https://github.com/rdytech/react-dashboard/pull/10 used gulp for generating `dist/react-dashboard.js`
Especially, in PR https://github.com/rdytech/react-dashboard/pull/9/files#diff-41117ee74403404af0abac6d7b22179cba090f336846010d55e9af875616177cL958
There were no dependency changes. However, `dist/react-dashboard.js` changed the format (removed white spaces) 
It seemed that we were manually updating `dist/react-dashboard.js`
- There is no Node version mentioned in README. In my M1 Macbook, I've tried node versions from 0.10 -> 14. none of them could get pass `npm install`. different errors (causes) in different node versions. I've also tried to create a Dockerfile and did `docker build --platform=linux/amd64 .`, didn't work.
- There is package-lock.json

We may have try it in an intel-based laptop, but I don't think it worths the effort for this PR.

